### PR TITLE
Switch from fixed Lifeline version to latest

### DIFF
--- a/fijibin/__init__.py
+++ b/fijibin/__init__.py
@@ -20,14 +20,13 @@ __all__ = ['fetch', 'macro']
 ##
 
 VERSION = open(join(dirname(__file__), 'VERSION')).read().strip()
-FIJI_VERSION = '20141125'
-BASE_URL = 'http://fiji.sc/downloads/Life-Line/fiji-'
-END_URL = '-' + FIJI_VERSION + '.zip'
+BASE_URL = 'https://downloads.imagej.net/fiji/latest/fiji-'
+END_URL = '.zip'
 
 HOME = os.path.expanduser('~')
 BIN_FOLDER = join(HOME, '.bin')
 EXTRACT_FOLDER = join(BIN_FOLDER, 'Fiji.app')
-FIJI_ROOT = join(BIN_FOLDER, 'Fiji-' + FIJI_VERSION + '.app')
+FIJI_ROOT = join(BIN_FOLDER, 'Fiji.app')
 BIN_NAMES = {
     'Darwin64bit': join(FIJI_ROOT, 'Contents/MacOS/ImageJ-macosx'),
     'Linux32bit': join(FIJI_ROOT, 'ImageJ-linux32'),


### PR DESCRIPTION
This change makes the download URL point to the latest releases instead of having a fixed Fiji version number (issue #1).

- Potential downsides of this solution is that users may get different versions of Fiji (depending on what is latest) and developers cannot restrict to a specific older version.
- Alternatively, one could build one fijibin package and publish to pypi whenever Fiji releases a new version. The developers can specify a fixed fijibin (and thus Fiji) version in requirements.
- Alternatively, one could require to call the `setup` manually after import (a [module init function](https://stackoverflow.com/questions/3720740/pass-variable-on-import/3720803#3720803)) and optionally pass a Fiji version number. That would be a breaking change, but not require anymore to frequently update the fijibin package.

For me the proposed changes work well enough. Any other thoughts?